### PR TITLE
路径不完整导致open_basedir越权拦截

### DIFF
--- a/AdminModule.php
+++ b/AdminModule.php
@@ -32,7 +32,7 @@ class AdminModule extends \yii\base\Module
 	public function configModuleParams(){
 		# 配置config文件
 		$config_file_dir = $this->_currentDir . '/etc/config.php';
-		if(file_exists($config_file_dir)){
+		if($this->_currentDir && file_exists($config_file_dir)){
 			$params_data = (require($config_file_dir));
 			
 		}


### PR DESCRIPTION
$this->_currentDir为空时PHP Warning 'yii\base\ErrorException' with message 'file_exists(): open_base xxxxxxx